### PR TITLE
Use sheet IDs in URL for read_gsheet() and COPY TO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 ## Copy to
-- [ ] header
+- [x] header
 - [ ] sheet
 - [ ] types
 - [ ] implicit copy to when it sees a gsheets url

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Copy to
 - [x] header
-- [ ] sheet
+- [x] sheet
 - [ ] types
 - [ ] implicit copy to when it sees a gsheets url
 - [x] warn when more than 2048 rows
@@ -19,5 +19,5 @@
 - [ ] Service Account keyfile
 
 ## Tests
-- Tests for read_gsheet()
-- Tests for copy to
+- [x] Tests for read_gsheet()
+- [x] Tests for copy to

--- a/src/gsheets_copy.cpp
+++ b/src/gsheets_copy.cpp
@@ -57,23 +57,17 @@ namespace duckdb
         std::string token = token_value.ToString();
         std::string spreadsheet_id = extract_spreadsheet_id(file_path);
         std::string sheet_id = extract_sheet_id(file_path);
-        std::string sheet_name = "Sheet1"; // TODO: make this configurable
+        std::string sheet_name = "Sheet1";
 
-        std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
-        json metadata = parseJson(metadata_response);
+        sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
 
-        for (const auto& sheet : metadata["sheets"]) {
-            if (sheet["properties"]["sheetId"].get<int>() == std::stoi(sheet_id)) {
-                sheet_name = sheet["properties"]["title"].get<std::string>();
-                break;
-            }
-        }
+        std::string encoded_sheet_name = url_encode(sheet_name);
 
         // If writing, clear out the entire sheet first.
         // Do this here in the initialization so that it only happens once
-        std::string response = delete_sheet_data(spreadsheet_id, token, sheet_name);
+        std::string response = delete_sheet_data(spreadsheet_id, token, encoded_sheet_name);
 
-        return make_uniq<GSheetCopyGlobalState>(context, spreadsheet_id, token, sheet_name);
+        return make_uniq<GSheetCopyGlobalState>(context, spreadsheet_id, token, encoded_sheet_name);
     }
 
     unique_ptr<LocalFunctionData> GSheetCopyFunction::GSheetWriteInitializeLocal(ExecutionContext &context, FunctionData &bind_data_p)
@@ -88,23 +82,13 @@ namespace duckdb
 
         std::string sheet_id = extract_sheet_id(bind_data_p.Cast<GSheetWriteBindData>().files[0]);
 
-        std::string metadata_response = get_spreadsheet_metadata(gstate.spreadsheet_id, gstate.token);
-        json metadata = parseJson(metadata_response);
-
         std::string sheet_name = "Sheet1";
 
-        for (const auto& sheet : metadata["sheets"]) {
-            if (sheet["properties"]["sheetId"].get<int>() == std::stoi(sheet_id)) {
-                sheet_name = sheet["properties"]["title"].get<std::string>();
-                break;
-            }
-        }
-
-
+        sheet_name = get_sheet_name_from_id(gstate.spreadsheet_id, sheet_id, gstate.token);
+        std::string encoded_sheet_name = url_encode(sheet_name);
         // Create object ready to write to Google Sheet
         json sheet_data;
 
-        // TODO: make this configurable
         sheet_data["range"] = sheet_name;
         sheet_data["majorDimension"] = "ROWS";
         
@@ -149,7 +133,7 @@ namespace duckdb
 
         // Make the API call to write data to the Google Sheet
         // Today, this is only append.
-        std::string response = fetch_sheet_data(gstate.spreadsheet_id, gstate.token, sheet_name, HttpMethod::POST, request_body);
+        std::string response = call_sheets_api(gstate.spreadsheet_id, gstate.token, encoded_sheet_name, HttpMethod::POST, request_body);
 
         // Check for errors in the response
         json response_json = parseJson(response);

--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -10,9 +10,9 @@ namespace duckdb {
 
 using json = nlohmann::json;
 
-ReadSheetBindData::ReadSheetBindData(string sheet_id, string token, bool header, string sheet_name) 
-    : sheet_id(sheet_id), token(token), finished(false), row_index(0), header(header), sheet_name(sheet_name) {
-    response = fetch_sheet_data(sheet_id, token, sheet_name, HttpMethod::GET);
+ReadSheetBindData::ReadSheetBindData(string spreadsheet_id, string token, bool header, string sheet_name) 
+    : spreadsheet_id(spreadsheet_id), token(token), finished(false), row_index(0), header(header), sheet_name(sheet_name) {
+    response = fetch_sheet_data(spreadsheet_id, token, sheet_name, HttpMethod::GET);
 }
 
 
@@ -96,8 +96,8 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
         }
     }
 
-    // Extract the sheet ID from the input (URL or ID)
-    std::string sheet_id = extract_sheet_id(sheet_input);
+    // Extract the spreadsheet ID from the input (URL or ID)
+    std::string spreadsheet_id = extract_spreadsheet_id(sheet_input);
 
     // Use the SecretManager to get the token
     auto &secret_manager = SecretManager::Get(context);
@@ -125,7 +125,7 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
 
     std::string token = token_value.ToString();
 
-    auto bind_data = make_uniq<ReadSheetBindData>(sheet_id, token, header, sheet);
+    auto bind_data = make_uniq<ReadSheetBindData>(spreadsheet_id, token, header, sheet);
 
     json cleanJson = parseJson(bind_data->response);
     SheetData sheet_data = getSheetData(cleanJson);

--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -115,7 +115,6 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
     // Get sheet name from URL
     std::string sheet_id = extract_sheet_id(sheet_input);
     sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
-    std::string encoded_sheet_name = url_encode(sheet_name);
 
     // Parse named parameters
     for (auto &kv : input.named_parameters) {
@@ -130,6 +129,7 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
         }
     }
 
+    std::string encoded_sheet_name = url_encode(sheet_name);
     
     auto bind_data = make_uniq<ReadSheetBindData>(spreadsheet_id, token, header, encoded_sheet_name);
 

--- a/src/gsheets_requests.cpp
+++ b/src/gsheets_requests.cpp
@@ -89,10 +89,10 @@ namespace duckdb
         return response;
     }
 
-    std::string fetch_sheet_data(const std::string &sheet_id, const std::string &token, const std::string &sheet_name, HttpMethod method, const std::string &body)
+    std::string fetch_sheet_data(const std::string &spreadsheet_id, const std::string &token, const std::string &sheet_name, HttpMethod method, const std::string &body)
     {
         std::string host = "sheets.googleapis.com";
-        std::string path = "/v4/spreadsheets/" + sheet_id + "/values/" + sheet_name;
+        std::string path = "/v4/spreadsheets/" + spreadsheet_id + "/values/" + sheet_name;
 
         if (method == HttpMethod::POST) {
             path += ":append";
@@ -102,11 +102,18 @@ namespace duckdb
         return perform_https_request(host, path, token, method, body);
     }
 
-    std::string delete_sheet_data(const std::string &sheet_id, const std::string &token, const std::string &sheet_name)
+    std::string delete_sheet_data(const std::string &spreadsheet_id, const std::string &token, const std::string &sheet_name)
     {
         std::string host = "sheets.googleapis.com";
-        std::string path = "/v4/spreadsheets/" + sheet_id + "/values/" + sheet_name + ":clear";
+        std::string path = "/v4/spreadsheets/" + spreadsheet_id + "/values/" + sheet_name + ":clear";
 
         return perform_https_request(host, path, token, HttpMethod::POST, "{}");
+    }
+
+    std::string get_spreadsheet_metadata(const std::string &spreadsheet_id, const std::string &token)
+    {
+        std::string host = "sheets.googleapis.com";
+        std::string path = "/v4/spreadsheets/" + spreadsheet_id + "?&fields=sheets.properties";
+        return perform_https_request(host, path, token, HttpMethod::GET, "");
     }
 }

--- a/src/gsheets_requests.cpp
+++ b/src/gsheets_requests.cpp
@@ -62,6 +62,8 @@ namespace duckdb
             request += body;
         }
 
+        
+
         if (BIO_write(bio, request.c_str(), request.length()) <= 0)
         {
             BIO_free_all(bio);
@@ -89,7 +91,7 @@ namespace duckdb
         return response;
     }
 
-    std::string fetch_sheet_data(const std::string &spreadsheet_id, const std::string &token, const std::string &sheet_name, HttpMethod method, const std::string &body)
+    std::string call_sheets_api(const std::string &spreadsheet_id, const std::string &token, const std::string &sheet_name, HttpMethod method, const std::string &body)
     {
         std::string host = "sheets.googleapis.com";
         std::string path = "/v4/spreadsheets/" + spreadsheet_id + "/values/" + sheet_name;

--- a/src/gsheets_utils.cpp
+++ b/src/gsheets_utils.cpp
@@ -7,22 +7,33 @@
 using json = nlohmann::json;
 namespace duckdb {
 
-std::string extract_sheet_id(const std::string& input) {
+std::string extract_spreadsheet_id(const std::string& input) {
     // Check if the input is already a sheet ID (no slashes)
     if (input.find('/') == std::string::npos) {
         return input;
     }
 
-    // Regular expression to match the sheet ID in a Google Sheets URL
+    // Regular expression to match the spreadsheet ID in a Google Sheets URL
     if(input.find("docs.google.com/spreadsheets/d/") != std::string::npos) {
-        std::regex sheet_id_regex("/d/([a-zA-Z0-9-_]+)");
+        std::regex spreadsheet_id_regex("/d/([a-zA-Z0-9-_]+)");
         std::smatch match;
 
-        if (std::regex_search(input, match, sheet_id_regex) && match.size() > 1) {
+        if (std::regex_search(input, match, spreadsheet_id_regex) && match.size() > 1) {
             return match.str(1);
         }
     }
 
+    throw duckdb::InvalidInputException("Invalid Google Sheets URL or ID");
+}
+
+std::string extract_sheet_id(const std::string& input) {
+    if (input.find("docs.google.com/spreadsheets/d/") != std::string::npos && input.find("edit?gid=") != std::string::npos) {
+        std::regex sheet_id_regex("gid=([0-9]+)");
+        std::smatch match;
+        if (std::regex_search(input, match, sheet_id_regex) && match.size() > 1) {
+            return match.str(1);
+        }
+    }
     throw duckdb::InvalidInputException("Invalid Google Sheets URL or ID");
 }
 

--- a/src/include/gsheets_copy.hpp
+++ b/src/include/gsheets_copy.hpp
@@ -8,13 +8,13 @@ namespace duckdb
 {
     struct GSheetCopyGlobalState : public GlobalFunctionData
     {
-        explicit GSheetCopyGlobalState(ClientContext &context, const string &sheet_id, const string &token, const string &sheet_name)
-            : sheet_id(sheet_id), token(token), sheet_name(sheet_name)
+        explicit GSheetCopyGlobalState(ClientContext &context, const string &spreadsheet_id, const string &token, const string &sheet_name)
+            : spreadsheet_id(spreadsheet_id), token(token), sheet_name(sheet_name)
         {
         }
 
     public:
-        string sheet_id;
+        string spreadsheet_id;
         string token;
         string sheet_name;
     };

--- a/src/include/gsheets_copy.hpp
+++ b/src/include/gsheets_copy.hpp
@@ -6,6 +6,37 @@
 
 namespace duckdb
 {
+    struct GSheetCopyGlobalState : public GlobalFunctionData
+    {
+        explicit GSheetCopyGlobalState(ClientContext &context, const string &sheet_id, const string &token, const string &sheet_name)
+            : sheet_id(sheet_id), token(token), sheet_name(sheet_name)
+        {
+        }
+
+    public:
+        string sheet_id;
+        string token;
+        string sheet_name;
+    };
+
+    struct GSheetWriteOptions
+    {
+        vector<string> name_list;
+    };
+
+    struct GSheetWriteBindData : public TableFunctionData
+    {
+        vector<string> files;
+        GSheetWriteOptions options;
+        vector<LogicalType> sql_types;
+
+        GSheetWriteBindData(string file_path, vector<LogicalType> sql_types, vector<string> names)
+            : sql_types(std::move(sql_types))
+        {
+            files.push_back(std::move(file_path));
+            options.name_list = std::move(names);
+        }
+    };
 
     class GSheetCopyFunction : public CopyFunction
     {

--- a/src/include/gsheets_read.hpp
+++ b/src/include/gsheets_read.hpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 struct ReadSheetBindData : public TableFunctionData {
-    string sheet_id;
+    string spreadsheet_id;
     string token;
     bool finished;
     idx_t row_index;
@@ -16,7 +16,7 @@ struct ReadSheetBindData : public TableFunctionData {
     bool header;
     string sheet_name;
 
-    ReadSheetBindData(string sheet_id, string token, bool header, string sheet_name);
+    ReadSheetBindData(string spreadsheet_id, string token, bool header, string sheet_name);
 };
 
 void ReadSheetFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);

--- a/src/include/gsheets_requests.hpp
+++ b/src/include/gsheets_requests.hpp
@@ -13,7 +13,7 @@ enum class HttpMethod {
 std::string perform_https_request(const std::string& host, const std::string& path, const std::string& token, 
                                   HttpMethod method = HttpMethod::GET, const std::string& body = "", const std::string& content_type = "application/json");
 
-std::string fetch_sheet_data(const std::string& spreadsheet_id, const std::string& token, const std::string& sheet_name, HttpMethod method = HttpMethod::GET, const std::string& body = "");
+std::string call_sheets_api(const std::string& spreadsheet_id, const std::string& token, const std::string& sheet_name, HttpMethod method = HttpMethod::GET, const std::string& body = "");
 
 std::string delete_sheet_data(const std::string& spreadsheet_id, const std::string& token, const std::string& sheet_name);
 

--- a/src/include/gsheets_requests.hpp
+++ b/src/include/gsheets_requests.hpp
@@ -13,8 +13,9 @@ enum class HttpMethod {
 std::string perform_https_request(const std::string& host, const std::string& path, const std::string& token, 
                                   HttpMethod method = HttpMethod::GET, const std::string& body = "", const std::string& content_type = "application/json");
 
-std::string fetch_sheet_data(const std::string& sheet_id, const std::string& token, const std::string& sheet_name, HttpMethod method = HttpMethod::GET, const std::string& body = "");
+std::string fetch_sheet_data(const std::string& spreadsheet_id, const std::string& token, const std::string& sheet_name, HttpMethod method = HttpMethod::GET, const std::string& body = "");
 
-std::string delete_sheet_data(const std::string& sheet_id, const std::string& token, const std::string& sheet_name);
+std::string delete_sheet_data(const std::string& spreadsheet_id, const std::string& token, const std::string& sheet_name);
 
+std::string get_spreadsheet_metadata(const std::string& spreadsheet_id, const std::string& token);
 }

--- a/src/include/gsheets_utils.hpp
+++ b/src/include/gsheets_utils.hpp
@@ -25,6 +25,24 @@ std::string extract_spreadsheet_id(const std::string& input);
  */
 std::string extract_sheet_id(const std::string& input);
 
+/**
+ * Gets the sheet name from a spreadsheet ID and sheet ID
+ * @param spreadsheet_id The spreadsheet ID
+ * @param sheet_id The sheet ID
+ * @param token The Google API token
+ * @return The sheet name
+ */
+std::string get_sheet_name_from_id(const std::string& spreadsheet_id, const std::string& sheet_id, const std::string& token);
+
+/**
+ * Gets the sheet ID from a spreadsheet ID and sheet name
+ * @param spreadsheet_id The spreadsheet ID
+ * @param sheet_name The sheet name
+ * @param token The Google API token
+ * @return The sheet ID
+ */
+std::string get_sheet_id_from_name(const std::string& spreadsheet_id, const std::string& sheet_name, const std::string& token);
+
 struct SheetData {
     std::string range;
     std::string majorDimension;
@@ -33,6 +51,11 @@ struct SheetData {
 
 SheetData getSheetData(const json& j);
 
+/**
+ * Parses a JSON string into a json object
+ * @param json_str The JSON string
+ * @return The parsed json object
+ */
 json parseJson(const std::string& json_str);
 
 /**
@@ -41,5 +64,13 @@ json parseJson(const std::string& json_str);
  * @return A random string of the specified length
  */
 std::string generate_random_string(size_t length);
+
+
+/**
+ * Encodes a string to be used in a URL
+ * @param str The string to encode
+ * @return The encoded string
+ */
+std::string url_encode(const std::string& str);
 
 } // namespace duckdb

--- a/src/include/gsheets_utils.hpp
+++ b/src/include/gsheets_utils.hpp
@@ -15,6 +15,14 @@ namespace duckdb {
  * @return The extracted sheet ID
  * @throws InvalidInputException if the input is neither a valid URL nor a sheet ID
  */
+std::string extract_spreadsheet_id(const std::string& input);
+
+
+/**
+ * Extracts the sheet ID from a Google Sheets URL
+ * @param input A Google Sheets URL
+ * @return The extracted sheet ID
+ */
 std::string extract_sheet_id(const std::string& input);
 
 struct SheetData {

--- a/test/sql/copy_to.test
+++ b/test/sql/copy_to.test
@@ -1,4 +1,4 @@
-# name: test/sql/copyto.test
+# name: test/sql/copy_to.test
 # description: test COPY TO function
 # group: [gsheets]
 

--- a/test/sql/copyto.test
+++ b/test/sql/copyto.test
@@ -1,0 +1,35 @@
+# name: test/sql/copyto.test
+# description: test COPY TO function
+# group: [gsheets]
+
+require-env TOKEN
+
+require gsheets
+
+# Create a secret NB must substitute a token, do not commit!
+statement ok
+create secret test_secret (type gsheet, token '${TOKEN}');
+
+# Create a table to copy to Google Sheet
+statement ok
+create table spreadsheets as 
+select 'Microsoft' as company, 'Excel' as product, 1985 as year_founded
+union all
+select 'Google', 'Google Sheets', 2006
+union all
+select 'Apple', 'Numbers', 1984
+union all
+select 'LibreOffice', 'Calc', 2000;
+
+# Copy the table to Google Sheet
+statement ok
+copy spreadsheets to 'https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit#gid=0' (format gsheet);
+
+# Read the table from Google Sheet
+query III
+from read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit#gid=0');
+----
+Microsoft	Excel	1985
+Google	Google Sheets	2006
+Apple	Numbers	1984
+LibreOffice	Calc	2000

--- a/test/sql/copyto.test
+++ b/test/sql/copyto.test
@@ -23,11 +23,11 @@ select 'LibreOffice', 'Calc', 2000;
 
 # Copy the table to Google Sheet
 statement ok
-copy spreadsheets to 'https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit#gid=0' (format gsheet);
+copy spreadsheets to 'https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=1295634987#gid=1295634987' (format gsheet);
 
 # Read the table from Google Sheet
 query III
-from read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit#gid=0');
+from read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=1295634987#gid=1295634987');
 ----
 Microsoft	Excel	1985
 Google	Google Sheets	2006

--- a/test/sql/read_gsheet.test
+++ b/test/sql/read_gsheet.test
@@ -1,5 +1,5 @@
-# name: test/sql/gsheets.test
-# description: test gsheets extension
+# name: test/sql/read_gsheet.test
+# description: test read_gsheet() function
 # group: [gsheets]
 
 require-env TOKEN


### PR DESCRIPTION
Resolves #8 

a generic GSheets URL is 

`https://docs.google.com/spreadsheets/d/<spreadsheet_id>/edit?gid=<sheet_id>#gid=<sheet_id>`

COPY TO
```sql
COPY <table> TO 'https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=1295634987#gid=1295634987';
```

read_gsheet()
```sql
FROM read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=1295634987#gid=1295634987');
```


it extracts the sheet ID (eg `1295634987` above) to determine which sheet in the workbook to read/write