### PR TITLE
fix Bug with failing double conversion #34

### DIFF
--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -53,10 +53,18 @@ void ReadSheetFunction(ClientContext &context, TableFunctionInput &data_p, DataC
                 const string& value = row[col];
                 switch (column_types[col].id()) {
                     case LogicalTypeId::BOOLEAN:
-                        output.SetValue(col, row_count, Value::BOOLEAN(value == "true"));
+                        if (value.empty()) {
+                            output.SetValue(col, row_count, Value(LogicalType::BOOLEAN));
+                        } else {
+                            output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::BOOLEAN));
+                        }
                         break;
                     case LogicalTypeId::DOUBLE:
-                        output.SetValue(col, row_count, Value::DOUBLE(std::stod(value)));
+                        if (value.empty()) {
+                            output.SetValue(col, row_count, Value(LogicalType::DOUBLE));
+                        } else {
+                            output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::DOUBLE));
+                        }
                         break;
                     default:
                         output.SetValue(col, row_count, Value(value));

--- a/test/sql/read_gsheet.test
+++ b/test/sql/read_gsheet.test
@@ -65,6 +65,14 @@ NULL
 NULL
 99.0
 
+# Issue 34: stod() fails on empty strings
+query III
+FROM read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=732080485#gid=732080485');
+----
+1.0	value1	blabla1
+2.0	value2	blabla2
+3.0	value3	blabla3
+NULL	value4	blabla4
 
 # Drop the secret
 statement ok


### PR DESCRIPTION
- Empty cells are returned as null for double and bool
- Other strings are converted using DefaultCastAs for safety