### PR TITLE
fix(reader): circumvent fetch sheet name from ID if user gives explicit sheet name

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+duckdb/.clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ token.txt
 .env
 _site/
 credentials.json
+compile_commands.json
+.cache/clangd/

--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -1,205 +1,216 @@
 #include "gsheets_read.hpp"
-#include "gsheets_utils.hpp"
+
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "gsheets_requests.hpp"
+#include "gsheets_utils.hpp"
+
 #include <json.hpp>
 
 namespace duckdb {
 
 using json = nlohmann::json;
 
-ReadSheetBindData::ReadSheetBindData(string spreadsheet_id, string token, bool header, string sheet_name) 
-    : spreadsheet_id(spreadsheet_id), token(token), finished(false), row_index(0), header(header), sheet_name(sheet_name) {
-    response = call_sheets_api(spreadsheet_id, token, sheet_name, HttpMethod::GET);
+ReadSheetBindData::ReadSheetBindData(string spreadsheet_id, string token, bool header, string sheet_name)
+    : spreadsheet_id(spreadsheet_id), token(token), finished(false), row_index(0), header(header),
+      sheet_name(sheet_name) {
+	response = call_sheets_api(spreadsheet_id, token, sheet_name, HttpMethod::GET);
 }
 
-bool IsValidNumber(const string& value) {
-    // Skip empty strings
-    if (value.empty()) {
-        return false;
-    }
-    
-    try {
-        // Try to parse as double
-        size_t processed;
-        std::stod(value, &processed);
-        // Ensure the entire string was processed
-        return processed == value.length();
-    } catch (...) {
-        return false;
-    }
+bool IsValidNumber(const string &value) {
+	// Skip empty strings
+	if (value.empty()) {
+		return false;
+	}
+
+	try {
+		// Try to parse as double
+		size_t processed;
+		std::stod(value, &processed);
+		// Ensure the entire string was processed
+		return processed == value.length();
+	} catch (...) {
+		return false;
+	}
 }
 
 void ReadSheetFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-    auto &bind_data = const_cast<ReadSheetBindData&>(data_p.bind_data->Cast<ReadSheetBindData>());
+	auto &bind_data = const_cast<ReadSheetBindData &>(data_p.bind_data->Cast<ReadSheetBindData>());
 
-    if (bind_data.finished) {
-        return;
-    }
-    
-    json cleanJson = parseJson(bind_data.response);
-    SheetData sheet_data = getSheetData(cleanJson);
+	if (bind_data.finished) {
+		return;
+	}
 
-    idx_t row_count = 0;
-    idx_t column_count = output.ColumnCount();
+	json cleanJson = parseJson(bind_data.response);
+	SheetData sheet_data = getSheetData(cleanJson);
 
-    // Adjust starting index based on whether we're using the header
-    idx_t start_index = bind_data.header ? bind_data.row_index + 1 : bind_data.row_index;
+	idx_t row_count = 0;
+	idx_t column_count = output.ColumnCount();
 
-    for (idx_t i = start_index; i < sheet_data.values.size() && row_count < STANDARD_VECTOR_SIZE; i++) {
-        const auto& row = sheet_data.values[i];
-        for (idx_t col = 0; col < column_count; col++) {
-            if (col < row.size()) {
-                const string& value = row[col];
-                switch (bind_data.return_types[col].id()) {
-                    case LogicalTypeId::BOOLEAN:
-                        if (value.empty()) {
-                            output.SetValue(col, row_count, Value(LogicalType::BOOLEAN));
-                        } else {
-                            output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::BOOLEAN));
-                        }
-                        break;
-                    case LogicalTypeId::DOUBLE:
-                        if (value.empty()) {
-                            output.SetValue(col, row_count, Value(LogicalType::DOUBLE));
-                        } else {
-                            output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::DOUBLE));
-                        }
-                        break;
-                    default:
-                        // Empty strings should be converted to NULL
-                        if (value.empty()) {
-                            output.SetValue(col, row_count, Value(LogicalType::VARCHAR));
-                        } else {
-                            output.SetValue(col, row_count, Value(value));
-                        }
-                        break;
-                }
-            } else {
-                output.SetValue(col, row_count, Value(nullptr));
-            }
-        }
-        row_count++;
-    }
+	// Adjust starting index based on whether we're using the header
+	idx_t start_index = bind_data.header ? bind_data.row_index + 1 : bind_data.row_index;
 
-    bind_data.row_index += row_count;
-    bind_data.finished = (bind_data.row_index >= (sheet_data.values.size() - (bind_data.header ? 1 : 0)));
+	for (idx_t i = start_index; i < sheet_data.values.size() && row_count < STANDARD_VECTOR_SIZE; i++) {
+		const auto &row = sheet_data.values[i];
+		for (idx_t col = 0; col < column_count; col++) {
+			if (col < row.size()) {
+				const string &value = row[col];
+				switch (bind_data.return_types[col].id()) {
+				case LogicalTypeId::BOOLEAN:
+					if (value.empty()) {
+						output.SetValue(col, row_count, Value(LogicalType::BOOLEAN));
+					} else {
+						output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::BOOLEAN));
+					}
+					break;
+				case LogicalTypeId::DOUBLE:
+					if (value.empty()) {
+						output.SetValue(col, row_count, Value(LogicalType::DOUBLE));
+					} else {
+						output.SetValue(col, row_count, Value(value).DefaultCastAs(LogicalType::DOUBLE));
+					}
+					break;
+				default:
+					// Empty strings should be converted to NULL
+					if (value.empty()) {
+						output.SetValue(col, row_count, Value(LogicalType::VARCHAR));
+					} else {
+						output.SetValue(col, row_count, Value(value));
+					}
+					break;
+				}
+			} else {
+				output.SetValue(col, row_count, Value(nullptr));
+			}
+		}
+		row_count++;
+	}
 
-    output.SetCardinality(row_count);
+	bind_data.row_index += row_count;
+	bind_data.finished = (bind_data.row_index >= (sheet_data.values.size() - (bind_data.header ? 1 : 0)));
+
+	output.SetCardinality(row_count);
 }
 
 unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types, vector<string> &names) {
-    auto sheet_input = input.inputs[0].GetValue<string>();
-    
-    // Default values
-    bool header = true;
-    string sheet_name = "Sheet1";
+                                       vector<LogicalType> &return_types, vector<string> &names) {
+	auto sheet_input = input.inputs[0].GetValue<string>();
 
-    // Extract the spreadsheet ID from the input (URL or ID)
-    std::string spreadsheet_id = extract_spreadsheet_id(sheet_input);
+	// Flags
+	bool use_explicit_sheet_name = false;
 
-    // Use the SecretManager to get the token
-    auto &secret_manager = SecretManager::Get(context);
-    auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-    auto secret_match = secret_manager.LookupSecret(transaction, "gsheet", "gsheet");
-    
-    if (!secret_match.HasMatch()) {
-        throw InvalidInputException("No 'gsheet' secret found. Please create a secret with 'CREATE SECRET' first.");
-    }
+	// Default values
+	bool header = true;
+	string sheet_name = "Sheet1";
+	string sheet_id = "0";
 
-    auto &secret = secret_match.GetSecret();
-    if (secret.GetType() != "gsheet") {
-        throw InvalidInputException("Invalid secret type. Expected 'gsheet', got '%s'", secret.GetType());
-    }
+	// Extract the spreadsheet ID from the input (URL or ID)
+	std::string spreadsheet_id = extract_spreadsheet_id(sheet_input);
 
-    const auto *kv_secret = dynamic_cast<const KeyValueSecret*>(&secret);
-    if (!kv_secret) {
-        throw InvalidInputException("Invalid secret format for 'gsheet' secret");
-    }
+	// Use the SecretManager to get the token
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto secret_match = secret_manager.LookupSecret(transaction, "gsheet", "gsheet");
 
-    Value token_value;
-    if (!kv_secret->TryGetValue("token", token_value)) {
-        throw InvalidInputException("'token' not found in 'gsheet' secret");
-    }
+	if (!secret_match.HasMatch()) {
+		throw InvalidInputException("No 'gsheet' secret found. Please create a secret with 'CREATE SECRET' first.");
+	}
 
-    std::string token = token_value.ToString();
+	auto &secret = secret_match.GetSecret();
+	if (secret.GetType() != "gsheet") {
+		throw InvalidInputException("Invalid secret type. Expected 'gsheet', got '%s'", secret.GetType());
+	}
 
-    // Get sheet name from URL
-    std::string sheet_id = extract_sheet_id(sheet_input);
-    sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
+	const auto *kv_secret = dynamic_cast<const KeyValueSecret *>(&secret);
+	if (!kv_secret) {
+		throw InvalidInputException("Invalid secret format for 'gsheet' secret");
+	}
 
-    // Parse named parameters
-    for (auto &kv : input.named_parameters) {
-        if (kv.first == "header") {
-            try {
-                header = kv.second.GetValue<bool>();
-            } catch (const std::exception& e) {
-                throw InvalidInputException("Invalid value for 'header' parameter. Expected a boolean value.");
-            }
-        } else if (kv.first == "sheet") {
-            sheet_name = kv.second.GetValue<string>();
-        }
-    }
+	Value token_value;
+	if (!kv_secret->TryGetValue("token", token_value)) {
+		throw InvalidInputException("'token' not found in 'gsheet' secret");
+	}
 
-    std::string encoded_sheet_name = url_encode(sheet_name);
-    
-    auto bind_data = make_uniq<ReadSheetBindData>(spreadsheet_id, token, header, encoded_sheet_name);
+	std::string token = token_value.ToString();
 
-    json cleanJson = parseJson(bind_data->response);
-    SheetData sheet_data = getSheetData(cleanJson);
+	// Parse named parameters
+	for (auto &kv : input.named_parameters) {
+		if (kv.first == "header") {
+			try {
+				header = kv.second.GetValue<bool>();
+			} catch (const std::exception &e) {
+				throw InvalidInputException("Invalid value for 'header' parameter. Expected a boolean value.");
+			}
+		} else if (kv.first == "sheet") {
+			use_explicit_sheet_name = true;
+			sheet_name = kv.second.GetValue<string>();
+			// Validates that sheet with name exists for a better user error message
+			sheet_id = get_sheet_id_from_name(spreadsheet_id, sheet_name, token);
+		}
+	}
 
-    // Prefering early return style to reduce nesting
-    if (sheet_data.values.empty()) {
-        return bind_data;
-    }
-    idx_t start_index = header ? 1 : 0;
-    if (start_index >= sheet_data.values.size()) {
-        return bind_data;
-    }
+	// Get sheet name from URL if user did not already provide one
+	if (!use_explicit_sheet_name) {
+		sheet_id = extract_sheet_id(sheet_input);
+		sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
+	}
 
-    const auto& first_data_row = sheet_data.values[start_index];
-    // If we have a header, we want the width of the result to be the max of:
-    //      the width of the header row
-    //      or the width of the first row of data
-    int result_width = first_data_row.size();
-    if (header) {
-        int header_width = sheet_data.values[0].size();
-        if (header_width > result_width) {
-            result_width = header_width;
-        }
-    }
-    
-    for (size_t i = 0; i < result_width; i++) {
-        // Assign default column_name, but rename to header value if using a header and header cell exists
-        string column_name = "column" + std::to_string(i + 1);
-        if (header && (i < sheet_data.values[0].size())) {
-            column_name = sheet_data.values[0][i];
-        }
-        names.push_back(column_name);
-        
-        // If the first row has blanks, assume varchar for now
-        if (i >= first_data_row.size()) {
-            return_types.push_back(LogicalType::VARCHAR);
-            continue;
-        } 
-        const string& value = first_data_row[i];
-        if (value == "TRUE" || value == "FALSE") {
-            return_types.push_back(LogicalType::BOOLEAN);
-        } else if (IsValidNumber(value)) {
-            return_types.push_back(LogicalType::DOUBLE);
-        } else {
-            return_types.push_back(LogicalType::VARCHAR);
-        }
-    }
+	std::string encoded_sheet_name = url_encode(sheet_name);
 
-    bind_data->names = names;
-    bind_data->return_types = return_types;
+	auto bind_data = make_uniq<ReadSheetBindData>(spreadsheet_id, token, header, encoded_sheet_name);
 
-    return bind_data;
+	json cleanJson = parseJson(bind_data->response);
+	SheetData sheet_data = getSheetData(cleanJson);
+
+	// Prefering early return style to reduce nesting
+	if (sheet_data.values.empty()) {
+		return bind_data;
+	}
+	idx_t start_index = header ? 1 : 0;
+	if (start_index >= sheet_data.values.size()) {
+		return bind_data;
+	}
+
+	const auto &first_data_row = sheet_data.values[start_index];
+	// If we have a header, we want the width of the result to be the max of:
+	//      the width of the header row
+	//      or the width of the first row of data
+	int result_width = first_data_row.size();
+	if (header) {
+		int header_width = sheet_data.values[0].size();
+		if (header_width > result_width) {
+			result_width = header_width;
+		}
+	}
+
+	for (size_t i = 0; i < result_width; i++) {
+		// Assign default column_name, but rename to header value if using a header and header cell exists
+		string column_name = "column" + std::to_string(i + 1);
+		if (header && (i < sheet_data.values[0].size())) {
+			column_name = sheet_data.values[0][i];
+		}
+		names.push_back(column_name);
+
+		// If the first row has blanks, assume varchar for now
+		if (i >= first_data_row.size()) {
+			return_types.push_back(LogicalType::VARCHAR);
+			continue;
+		}
+		const string &value = first_data_row[i];
+		if (value == "TRUE" || value == "FALSE") {
+			return_types.push_back(LogicalType::BOOLEAN);
+		} else if (IsValidNumber(value)) {
+			return_types.push_back(LogicalType::DOUBLE);
+		} else {
+			return_types.push_back(LogicalType::VARCHAR);
+		}
+	}
+
+	bind_data->names = names;
+	bind_data->return_types = return_types;
+
+	return bind_data;
 }
 
 } // namespace duckdb
-

--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -1,7 +1,6 @@
 #include "gsheets_read.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "gsheets_requests.hpp"
 #include "gsheets_utils.hpp"

--- a/src/gsheets_utils.cpp
+++ b/src/gsheets_utils.cpp
@@ -1,140 +1,143 @@
 #include "gsheets_utils.hpp"
-#include "gsheets_requests.hpp"
+
 #include "duckdb/common/exception.hpp"
-#include <regex>
-#include <json.hpp>
+#include "gsheets_requests.hpp"
+
 #include <iostream>
+#include <json.hpp>
+#include <regex>
 #include <sstream>
 
 using json = nlohmann::json;
 namespace duckdb {
 
-std::string extract_spreadsheet_id(const std::string& input) {
-    // Check if the input is already a sheet ID (no slashes)
-    if (input.find('/') == std::string::npos) {
-        return input;
-    }
+std::string extract_spreadsheet_id(const std::string &input) {
+	// Check if the input is already a sheet ID (no slashes)
+	if (input.find('/') == std::string::npos) {
+		return input;
+	}
 
-    // Regular expression to match the spreadsheet ID in a Google Sheets URL
-    if(input.find("docs.google.com/spreadsheets/d/") != std::string::npos) {
-        std::regex spreadsheet_id_regex("/d/([a-zA-Z0-9-_]+)");
-        std::smatch match;
+	// Regular expression to match the spreadsheet ID in a Google Sheets URL
+	if (input.find("docs.google.com/spreadsheets/d/") != std::string::npos) {
+		std::regex spreadsheet_id_regex("/d/([a-zA-Z0-9-_]+)");
+		std::smatch match;
 
-        if (std::regex_search(input, match, spreadsheet_id_regex) && match.size() > 1) {
-            return match.str(1);
-        }
-    }
+		if (std::regex_search(input, match, spreadsheet_id_regex) && match.size() > 1) {
+			return match.str(1);
+		}
+	}
 
-    throw duckdb::InvalidInputException("Invalid Google Sheets URL or ID");
+	throw duckdb::InvalidInputException("Invalid Google Sheets URL or ID");
 }
 
-std::string extract_sheet_id(const std::string& input) {
-    if (input.find("docs.google.com/spreadsheets/d/") != std::string::npos && input.find("gid=") != std::string::npos) {
-        std::regex sheet_id_regex("gid=([0-9]+)");
-        std::smatch match;
-        if (std::regex_search(input, match, sheet_id_regex) && match.size() > 1) {
-            return match.str(1);
-        }
-    }
-    return "0";
+std::string extract_sheet_id(const std::string &input) {
+	if (input.find("docs.google.com/spreadsheets/d/") != std::string::npos && input.find("gid=") != std::string::npos) {
+		std::regex sheet_id_regex("gid=([0-9]+)");
+		std::smatch match;
+		if (std::regex_search(input, match, sheet_id_regex) && match.size() > 1) {
+			return match.str(1);
+		}
+	}
+	return "0";
 }
 
-std::string get_sheet_name_from_id(const std::string& spreadsheet_id, const std::string& sheet_id, const std::string& token) {
-    std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
-    json metadata = parseJson(metadata_response);
-    for (const auto& sheet : metadata["sheets"]) {
-        if (sheet["properties"]["sheetId"].get<int>() == std::stoi(sheet_id)) {
-            return sheet["properties"]["title"].get<std::string>();
-        }
-    }
-    throw duckdb::InvalidInputException("Sheet with ID %s not found", sheet_id);
+std::string get_sheet_name_from_id(const std::string &spreadsheet_id, const std::string &sheet_id,
+                                   const std::string &token) {
+	std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
+	json metadata = parseJson(metadata_response);
+	for (const auto &sheet : metadata["sheets"]) {
+		if (sheet["properties"]["sheetId"].get<int>() == std::stoi(sheet_id)) {
+			return sheet["properties"]["title"].get<std::string>();
+		}
+	}
+	throw duckdb::InvalidInputException("Sheet with ID %s not found", sheet_id);
 }
 
-std::string get_sheet_id_from_name(const std::string& spreadsheet_id, const std::string& sheet_name, const std::string& token) {
-    std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
-    json metadata = parseJson(metadata_response);
-    for (const auto& sheet : metadata["sheets"]) {
-        if (sheet["properties"]["title"].get<std::string>() == sheet_name) {
-            return sheet["properties"]["sheetId"].get<std::string>();
-        }
-    }
-    throw duckdb::InvalidInputException("Sheet with name %s not found", sheet_name);
+std::string get_sheet_id_from_name(const std::string &spreadsheet_id, const std::string &sheet_name,
+                                   const std::string &token) {
+	std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
+	json metadata = parseJson(metadata_response);
+	for (const auto &sheet : metadata["sheets"]) {
+		if (sheet["properties"]["title"].get<std::string>() == sheet_name) {
+			return std::to_string(sheet["properties"]["sheetId"].get<int>());
+		}
+	}
+	throw duckdb::InvalidInputException("Sheet with name %s not found", sheet_name);
 }
 
-json parseJson(const std::string& json_str) {
-    try {
-        // Find the start of the JSON object
-        size_t start = json_str.find('{');
-        if (start == std::string::npos) {
-            throw std::runtime_error("No JSON object found in the response");
-        }
+json parseJson(const std::string &json_str) {
+	try {
+		// Find the start of the JSON object
+		size_t start = json_str.find('{');
+		if (start == std::string::npos) {
+			throw std::runtime_error("No JSON object found in the response");
+		}
 
-        // Find the end of the JSON object
-        size_t end = json_str.rfind('}');
-        if (end == std::string::npos) {
-            throw std::runtime_error("No closing brace found in the JSON response");
-        }
+		// Find the end of the JSON object
+		size_t end = json_str.rfind('}');
+		if (end == std::string::npos) {
+			throw std::runtime_error("No closing brace found in the JSON response");
+		}
 
-        // Extract the JSON object
-        std::string clean_json = json_str.substr(start, end - start + 1);
+		// Extract the JSON object
+		std::string clean_json = json_str.substr(start, end - start + 1);
 
-        json j = json::parse(clean_json);
-        return j;
-    } catch (const json::exception& e) {
-        std::cerr << "JSON parsing error: " << e.what() << std::endl;
-        std::cerr << "Raw JSON string: " << json_str << std::endl;
-        throw;
-    }
+		json j = json::parse(clean_json);
+		return j;
+	} catch (const json::exception &e) {
+		std::cerr << "JSON parsing error: " << e.what() << std::endl;
+		std::cerr << "Raw JSON string: " << json_str << std::endl;
+		throw;
+	}
 }
 
-SheetData getSheetData(const json& j) {
-    SheetData result;
-    if (j.contains("range") && j.contains("majorDimension") && j.contains("values")) {
-        result.range = j["range"].get<std::string>();
-        result.majorDimension = j["majorDimension"].get<std::string>();
-        result.values = j["values"].get<std::vector<std::vector<std::string>>>();
-    } else if (j.contains("error")) {
-        string message = j["error"]["message"].get<std::string>();
-            int code = j["error"]["code"].get<int>();
-            throw std::runtime_error("Google Sheets API error: " + std::to_string(code) + " - " + message);
-        } else {
-        std::cerr << "JSON does not contain expected fields" << std::endl;
-        std::cerr << "Raw JSON string: " << j.dump() << std::endl;
-        throw;
-    }
-    return result;
+SheetData getSheetData(const json &j) {
+	SheetData result;
+	if (j.contains("range") && j.contains("majorDimension") && j.contains("values")) {
+		result.range = j["range"].get<std::string>();
+		result.majorDimension = j["majorDimension"].get<std::string>();
+		result.values = j["values"].get<std::vector<std::vector<std::string>>>();
+	} else if (j.contains("error")) {
+		string message = j["error"]["message"].get<std::string>();
+		int code = j["error"]["code"].get<int>();
+		throw std::runtime_error("Google Sheets API error: " + std::to_string(code) + " - " + message);
+	} else {
+		std::cerr << "JSON does not contain expected fields" << std::endl;
+		std::cerr << "Raw JSON string: " << j.dump() << std::endl;
+		throw;
+	}
+	return result;
 }
 
 std::string generate_random_string(size_t length) {
-    static const char charset[] =
-        "0123456789"
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz";
+	static const char charset[] = "0123456789"
+	                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	                              "abcdefghijklmnopqrstuvwxyz";
 
-    std::random_device rd;
-    std::mt19937 generator(rd());
-    std::uniform_int_distribution<> distribution(0, sizeof(charset) - 2);
+	std::random_device rd;
+	std::mt19937 generator(rd());
+	std::uniform_int_distribution<> distribution(0, sizeof(charset) - 2);
 
-    std::string result;
-    result.reserve(length);
-    for (size_t i = 0; i < length; ++i) {
-        result.push_back(charset[distribution(generator)]);
-    }
-    return result;
+	std::string result;
+	result.reserve(length);
+	for (size_t i = 0; i < length; ++i) {
+		result.push_back(charset[distribution(generator)]);
+	}
+	return result;
 }
 
-std::string url_encode(const std::string& str) {
-    std::string encoded;
-    for (char c : str) {
-        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
-            encoded += c;
-        } else {
-            std::stringstream ss;
-            ss << std::hex << std::uppercase << static_cast<int>(static_cast<unsigned char>(c));
-            encoded += '%' + ss.str();
-        }
-    }
-    return encoded;
+std::string url_encode(const std::string &str) {
+	std::string encoded;
+	for (char c : str) {
+		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+			encoded += c;
+		} else {
+			std::stringstream ss;
+			ss << std::hex << std::uppercase << static_cast<int>(static_cast<unsigned char>(c));
+			encoded += '%' + ss.str();
+		}
+	}
+	return encoded;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Related to #51 but does not solve the full issue. I just wanted to do a small PR to get a feel for building and testing the project.

This is just a small fix that avoids the fetch metadata to get the sheet name from ID if the user gives the sheet name already. This doesn't fully avoid a network call to fetch metadata because it still does it to get ID from name so that we can correctly report to the user a sheet with name "XXXX" not found error.

Next steps (follow-up PRs):

- [ ] Fallback to sheet with *index* 0 if name not given and ID not found in input string
- [ ] Possibly add `index` input arg but currently I think we can avoid that in favor of `sheet` which already exists

Misc changes:

- Hoisted `.clang-format` up from DuckDB repo so I didn't have to worry about having an opinion on formatting
- Add rule to ignore CMake and clangd artifacts from git