### PR TITLE
fix(reader): default to first sheet by index if no ID found

### DIFF
--- a/src/gsheets_read.cpp
+++ b/src/gsheets_read.cpp
@@ -94,12 +94,12 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
     auto sheet_input = input.inputs[0].GetValue<string>();
 
     // Flags
-    bool use_explicit_sheet_name = false;
-    
-    // Default values
     bool header = true;
-    string sheet_name = "Sheet1";
-    string sheet_id = "0";
+    bool use_explicit_sheet_name = false;
+
+    // Default values
+    string sheet_name = "";
+    string sheet_id = "";
 
     // Extract the spreadsheet ID from the input (URL or ID)
     std::string spreadsheet_id = extract_spreadsheet_id(sheet_input);
@@ -150,7 +150,12 @@ unique_ptr<FunctionData> ReadSheetBind(ClientContext &context, TableFunctionBind
     // Get sheet name from URL if not provided as input
     if (!use_explicit_sheet_name) {
         sheet_id = extract_sheet_id(sheet_input);
-        sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
+        if (sheet_id.empty()) {
+            // Fallback to first sheet by index
+            sheet_name = get_sheet_name_from_index(spreadsheet_id, "0", token);
+        } else {
+            sheet_name = get_sheet_name_from_id(spreadsheet_id, sheet_id, token);
+        }
     }
 
     std::string encoded_sheet_name = url_encode(sheet_name);

--- a/src/gsheets_utils.cpp
+++ b/src/gsheets_utils.cpp
@@ -5,7 +5,6 @@
 #include <json.hpp>
 #include <iostream>
 #include <sstream>
-#include <string>
 
 using json = nlohmann::json;
 namespace duckdb {
@@ -37,7 +36,7 @@ std::string extract_sheet_id(const std::string& input) {
             return match.str(1);
         }
     }
-    return "0";
+    return "";
 }
 
 std::string get_sheet_name_from_id(const std::string& spreadsheet_id, const std::string& sheet_id, const std::string& token) {
@@ -49,6 +48,17 @@ std::string get_sheet_name_from_id(const std::string& spreadsheet_id, const std:
         }
     }
     throw duckdb::InvalidInputException("Sheet with ID %s not found", sheet_id);
+}
+
+std::string get_sheet_name_from_index(const std::string& spreadsheet_id, const std::string& sheet_index, const std::string& token) {
+    std::string metadata_response = get_spreadsheet_metadata(spreadsheet_id, token);
+    json metadata = parseJson(metadata_response);
+    for (const auto& sheet : metadata["sheets"]) {
+        if (sheet["properties"]["index"].get<int>() == std::stoi(sheet_index)) {
+            return sheet["properties"]["title"].get<std::string>();
+        }
+    }
+    throw duckdb::InvalidInputException("Sheet with index %s not found", sheet_index);
 }
 
 std::string get_sheet_id_from_name(const std::string& spreadsheet_id, const std::string& sheet_name, const std::string& token) {

--- a/src/include/gsheets_utils.hpp
+++ b/src/include/gsheets_utils.hpp
@@ -35,6 +35,15 @@ std::string extract_sheet_id(const std::string& input);
 std::string get_sheet_name_from_id(const std::string& spreadsheet_id, const std::string& sheet_id, const std::string& token);
 
 /**
+ * Gets the sheet name from a spreadsheet ID and sheet ID
+ * @param spreadsheet_id The spreadsheet ID
+ * @param sheet_index The sheet index (zero-based)
+ * @param token The Google API token
+ * @return The sheet name
+ */
+std::string get_sheet_name_from_index(const std::string& spreadsheet_id, const std::string& sheet_index, const std::string& token);
+
+/**
  * Gets the sheet ID from a spreadsheet ID and sheet name
  * @param spreadsheet_id The spreadsheet ID
  * @param sheet_name The sheet name


### PR DESCRIPTION
Fixes bug where we assumed that the first sheet in the spreadsheet would have ID 0 but this can be false like when the user rearranges the sheets or deletes the first sheet.

This is a breaking change for some users that were inadvertently getting the first sheet created even if it wasn't the first sheet by index.

Additionally, this adds a new util function, `get_sheet_name_from_index`, that works similarily to `get_sheet_name_from_id`. If we do decide to add new named input for user to select a sheet by index instead of by name then this will allow that feature work to be trivial. For now, it's just used to get the first sheet by index as a fallback if no ID is found in the user input _and_ no sheet name is provided.

Closes #51 