### PR TITLE
fix(reader): handle header-only results

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -118,7 +118,6 @@ This token will periodically expire - you can re-run the above command again to 
 
 - DuckDB WASM is not (yet) supported.
 - Google Sheets has a limit of 10,000,000 cells per spreadsheet.
-- Writing data to a sheet starting from a cell other than A1 is not yet supported.
 - Sheets must already exist to COPY TO them.
 
 ## Support 

--- a/test/sql/read_gsheet.test
+++ b/test/sql/read_gsheet.test
@@ -109,7 +109,11 @@ NULL	NULL
 Archie	99.0
 
 # Test single value from range
-# NOTE: *must* use `header=false` to avoid uncaught bind error
+query I
+FROM read_gsheet('11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8', sheet='Sheet1', range='A2');
+----
+
+# Test single value from range (no headers)
 query I
 FROM read_gsheet('11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8', sheet='Sheet1', range='A2', header=false);
 ----
@@ -167,6 +171,17 @@ FROM read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8
 ----
 woot	blah	NULL	should get this!
 more wooting	more blah	NULL	should get this!
+
+# Header only results
+query II
+FROM read_gsheet('11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8', sheet='62-header_only');
+----
+
+# Empty sheet
+statement error
+FROM read_gsheet('11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8', sheet='62-empty');
+----
+Invalid Input Error: Sheet 62-empty is empty
 
 # Drop the secret
 statement ok


### PR DESCRIPTION
Closes #62

Issue was that single cell results are the same as header-only results. For header-only results we returned bind data too early without setting column name and types so when bind function was called by DuckDB it failed due to empty schema error.

This makes the following changes to avoid this:

- [x] Catch empty results and throw custom exception to tell user the exact cause of error
- [x] Avoid segfault when trying to access first row at index 1 when header-only results

The following tests were added to catch these issues in the future

- [x] Read sheet with single cell range (w/ headers)
- [x] Read sheet with single cell range (w/o headers)
- [x] Read header-only sheet
- [x] Read empty sheet
