### PR TITLE
chore: upgrade duckdb to v1.3.1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+duckdb/.clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ token.txt
 _site/
 credentials.json
 compile_commands.json
+compile_flags.txt
 .cache/clangd/
 .helix/

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -24,7 +24,7 @@ INSTALL gsheets FROM community;
 LOAD gsheets;
 ```
 
-The latest version of [DuckDB](https://duckdb.org/docs/installation) (currently 1.2.0) is supported.
+The latest version of [DuckDB](https://duckdb.org/docs/installation) (currently 1.3.1) is supported.
 
 ## Usage 
 

--- a/src/gsheets_get_token.cpp
+++ b/src/gsheets_get_token.cpp
@@ -188,7 +188,7 @@ namespace duckdb
         auto old_secret = secret_manager.GetSecretByName(transaction, secret_name);
         auto persist_type = old_secret->persist_type;
         auto storage_mode = old_secret->storage_mode;
-        CreateSecretInfo create_secret_info = CreateSecretInfo(OnCreateConflict::REPLACE_ON_CONFLICT, persist_type);
+        auto create_secret_info = make_uniq<CreateSecretInfo>(OnCreateConflict::REPLACE_ON_CONFLICT, persist_type);
 
         // Copy the old secret (to get metadata about the secret we want to maintain)
         auto new_secret = old_secret->secret->Clone().get();


### PR DESCRIPTION
Closes #78 

Seemed like upgrading resulted in a new compilation error. I'm assuming one of the DuckDB C++ APIs changes since there is no guaranteed stability there. That is resolved and everything compiles and all of the tests are passing. 