### PR TITLE
fix(auth): use-after-free bug when trying to find gsheet secret

### DIFF
--- a/src/include/utils/secret.hpp
+++ b/src/include/utils/secret.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
 namespace sheets {
 
 const SecretMatch GetSecretMatch(ClientContext &ctx, const std::string &path, const std::string &type);
-const KeyValueSecret *GetGSheetSecret(ClientContext &ctx);
 
 } // namespace sheets
 } // namespace duckdb

--- a/src/sheets/auth_factory.cpp
+++ b/src/sheets/auth_factory.cpp
@@ -8,28 +8,29 @@ namespace duckdb {
 namespace sheets {
 
 std::unique_ptr<IAuthProvider> CreateAuthFromSecret(ClientContext &ctx, IHttpClient &http) {
-	auto *secret = GetGSheetSecret(ctx);
-	if (!secret) {
-		return nullptr;
+	auto match = GetSecretMatch(ctx, "gsheet", "gsheet");
+	if (match.HasMatch()) {
+		auto &secret = match.GetSecret();
+		auto gsheet_secret = dynamic_cast<const KeyValueSecret *>(&secret);
+		auto provider = gsheet_secret->GetProvider();
+		if (provider == "key_file") {
+			Value emailValue, keyValue;
+			if (!gsheet_secret->TryGetValue("email", emailValue)) {
+				throw InvalidInputException("'email' not found in gsheet secret");
+			}
+			if (!gsheet_secret->TryGetValue("secret", keyValue)) {
+				throw InvalidInputException("'secret' not found in gsheet secret");
+			}
+			return make_uniq<ServiceAccountAuth>(http, emailValue.ToString(), keyValue.ToString());
+		} else {
+			Value tokenValue;
+			if (!gsheet_secret->TryGetValue("token", tokenValue)) {
+				throw InvalidInputException("'token' not found in gsheet secret");
+			}
+			return make_uniq<BearerTokenAuth>(tokenValue.ToString());
+		}
 	}
-
-	auto provider = secret->GetProvider();
-	if (provider == "key_file") {
-		Value emailValue, keyValue;
-		if (!secret->TryGetValue("email", emailValue)) {
-			throw InvalidInputException("'email' not found in gsheet secret");
-		}
-		if (!secret->TryGetValue("secret", keyValue)) {
-			throw InvalidInputException("'secret' not found in gsheet secret");
-		}
-		return make_uniq<ServiceAccountAuth>(http, emailValue.ToString(), keyValue.ToString());
-	} else {
-		Value tokenValue;
-		if (!secret->TryGetValue("token", tokenValue)) {
-			throw InvalidInputException("'token' not found in gsheet secret");
-		}
-		return make_uniq<BearerTokenAuth>(tokenValue.ToString());
-	}
+	return nullptr;
 }
 
 } // namespace sheets

--- a/src/utils/secret.cpp
+++ b/src/utils/secret.cpp
@@ -19,7 +19,7 @@ const KeyValueSecret *GetGSheetSecret(ClientContext &ctx) {
 		return nullptr;
 	}
 	auto &secret = match.GetSecret();
-	return dynamic_cast<const KeyValueSecret *>(&secret);
+	return static_cast<const KeyValueSecret *>(&secret);
 }
 
 } // namespace sheets

--- a/src/utils/secret.cpp
+++ b/src/utils/secret.cpp
@@ -1,6 +1,5 @@
 #include "utils/secret.hpp"
 
-#include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/catalog/catalog_transaction.hpp"
 
@@ -11,15 +10,6 @@ const SecretMatch GetSecretMatch(ClientContext &ctx, const std::string &path, co
 	auto &manager = SecretManager::Get(ctx);
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(ctx);
 	return manager.LookupSecret(transaction, path, type);
-}
-
-const KeyValueSecret *GetGSheetSecret(ClientContext &ctx) {
-	auto match = GetSecretMatch(ctx, "gsheet", "gsheet");
-	if (!match.HasMatch()) {
-		return nullptr;
-	}
-	auto &secret = match.GetSecret();
-	return static_cast<const KeyValueSecret *>(&secret);
 }
 
 } // namespace sheets


### PR DESCRIPTION
## Overview

Fixes a use-after-free bug in `GetGSheetSecret` that caused `read_gsheet` and `COPY TO` to fail on macOS with `'token' not found in gsheet secret`.

`GetGSheetSecret` returned a raw `KeyValueSecret *` pointing into a `SecretMatch` that was destroyed when the function returned. The caller then read from freed memory. On Linux the allocator happened to leave the memory intact, masking the bug. On macOS the allocator reclaims the memory sooner, causing `secret_map` to appear empty.

The fix inlines the secret access into `CreateAuthFromSecret` so the `SecretMatch` stays alive on the stack for the duration of use. `GetGSheetSecret` is removed.